### PR TITLE
Support for Solus OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # serverscripts
 Automate Setup Server Services
 
-####Table Of Content
+Table Of Content
 ====================
 * [automate_samba](/automate_samba) 
+    - `install-samba.sh` will install and interactively configure samba on your machine.
+    - `addnew-sambauser.sh` will configure a new user on your samba server.
     - Tested on Fedora, Ubuntu, Arch, Solus, Manjaro.

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ Table Of Content
 * [automate_samba](/automate_samba) 
     - `install-samba.sh` will install and interactively configure samba on your machine.
     - `addnew-sambauser.sh` will configure a new user on your samba server.
+    - You might need to configure firewall/iptables to allow samba trafic.
     - Tested on Fedora, Ubuntu, Arch, Solus, Manjaro.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # serverscripts
-automate setup server services
+Automate Setup Server Services
+
+####Table Of Content
+====================
+* [automate_samba](/automate_samba) 
+    - Tested on Fedora, Ubuntu, Arch, Solus, Manjaro.

--- a/automate_samba/addnew-sambauser.sh
+++ b/automate_samba/addnew-sambauser.sh
@@ -7,6 +7,14 @@
 #         https://askubuntu.com/questions/88108/samba-share-read-only-for-guests-read-write-for-authenticated-users
 #         https://getsol.us/articles/software/samba/en/
 
+
+# Check for sudo access
+
+if [ "$(id -u)" != "0" ]; then
+	echo "Sorry, you need to run this with sudo."
+	exit 1
+fi
+
 Color_Off='\e[0m'
 Black='\e[0;30m'
 Red='\e[0;31m'

--- a/automate_samba/addnew-sambauser.sh
+++ b/automate_samba/addnew-sambauser.sh
@@ -5,6 +5,7 @@
 # DEMO:   https://youtu.be/HGO4lqh0LN8
 # REFF:   https://www.digitalocean.com/community/tutorials/how-to-set-up-a-samba-share-for-a-small-organization-on-ubuntu-16-04
 #         https://askubuntu.com/questions/88108/samba-share-read-only-for-guests-read-write-for-authenticated-users
+#         https://getsol.us/articles/software/samba/en/
 
 Color_Off='\e[0m'
 Black='\e[0;30m'
@@ -72,10 +73,12 @@ elif [ "$PKMGR" = "pacman" ]; then
   systemctl restart nmb.service smb.service
 elif [ "$PKMGR" = "zypper" ]; then
   systemctl restart nmb.service smb.service
+elif [ "$PKMGR" = "eopkg" ]; then
+  systemctl restart nmb.service smb.service
 fi
 
 
 printf "%s\n"
 
-MY_IP="$(ip addr | awk '/global/ {print $1,$2}' | cut -d\/ -f1 | cut -d' ' -f2)"
-echo -e "${Yellow}>>>Server will be hosted at smb://$MY_IP${Color_Off}"
+MY_IP="$(ip addr | awk '/global/ {print $1,$2}' | cut -d\/ -f1 | cut -d' ' -f2 | head -n 1)"
+echo -e "${Yellow}>>>Server will be hosted at ${Red}smb://$MY_IP${Color_Off}"

--- a/automate_samba/addnew-sambauser.sh
+++ b/automate_samba/addnew-sambauser.sh
@@ -66,7 +66,7 @@ smbpasswd -e "$USERNAME"
 
 # restart service
 find_pkm() { for i;do which "$i" > /dev/null 2>&1 && { echo "$i"; return 0;};done;return 1; }
-PKMGR=$(find_pkm apt aptitude apt-get dnf emerge pacman zypper)
+PKMGR=$(find_pkm apt aptitude apt-get dnf emerge pacman zypper eopkg)
 if [ "$PKMGR" = "apt" ]; then
   systemctl restart nmbd.service smbd.service
 elif [ "$PKMGR" = "apt-get" ]; then

--- a/automate_samba/install-samba.sh
+++ b/automate_samba/install-samba.sh
@@ -5,6 +5,7 @@
 # DEMO:   https://youtu.be/HGO4lqh0LN8
 # REFF:   https://www.digitalocean.com/community/tutorials/how-to-set-up-a-samba-share-for-a-small-organization-on-ubuntu-16-04
 #         https://askubuntu.com/questions/88108/samba-share-read-only-for-guests-read-write-for-authenticated-users
+#         https://getsol.us/articles/software/samba/en/
 
 Color_Off='\e[0m'
 Black='\e[0;30m'
@@ -18,7 +19,7 @@ White='\e[0;37m'
 
 # install required packages
 find_pkm() { for i;do which "$i" > /dev/null 2>&1 && { echo "$i"; return 0;};done;return 1; }
-PKMGR=$(find_pkm apt aptitude apt-get dnf emerge pacman zypper)
+PKMGR=$(find_pkm apt aptitude apt-get dnf emerge pacman zypper eopkg)
 if [ "$PKMGR" = "apt" ]; then
   apt update
   apt install -y samba coreutils sed gawk
@@ -40,6 +41,9 @@ elif [ "$PKMGR" = "pacman" ]; then
 elif [ "$PKMGR" = "zypper" ]; then
   zypper refresh
   zypper install -y samba coreutils sed gawk
+elif [ "$PKMGR" = "eopkg" ]; then
+  eopkg up
+  eopkg it samba sed gawk coreutils
 fi
 
 printf "%s\n"
@@ -120,9 +124,11 @@ elif [ "$PKMGR" = "pacman" ]; then
   systemctl enable --now nmb.service smb.service
 elif [ "$PKMGR" = "zypper" ]; then
   systemctl enable --now nmb.service smb.service
+elif [ "$PKMGR" = "eopkg" ]; then
+  systemctl enable --now smb.service nmb.service
 fi
 
 printf "%s\n"
 
-MY_IP="$(ip addr | awk '/global/ {print $1,$2}' | cut -d\/ -f1 | cut -d' ' -f2)"
-echo -e "${Yellow}>>>Server will be hosted at smb://$MY_IP or smb://$SERVERNAME${Color_Off}"
+MY_IP="$(ip addr | awk '/global/ {print $1,$2}' | cut -d\/ -f1 | cut -d' ' -f2 | head -n 1)"
+echo -e "${Yellow}>>>Server will be hosted at ${Red}smb://$MY_IP ${Yellow}or ${Red}smb://$SERVERNAME${Color_Off}"

--- a/automate_samba/install-samba.sh
+++ b/automate_samba/install-samba.sh
@@ -7,6 +7,14 @@
 #         https://askubuntu.com/questions/88108/samba-share-read-only-for-guests-read-write-for-authenticated-users
 #         https://getsol.us/articles/software/samba/en/
 
+
+# Check for sudo access
+
+if [ "$(id -u)" != "0" ]; then
+	echo "Sorry, you need to run this with sudo."
+	exit 1
+fi
+
 Color_Off='\e[0m'
 Black='\e[0;30m'
 Red='\e[0;31m'
@@ -132,3 +140,4 @@ printf "%s\n"
 
 MY_IP="$(ip addr | awk '/global/ {print $1,$2}' | cut -d\/ -f1 | cut -d' ' -f2 | head -n 1)"
 echo -e "${Yellow}>>>Server will be hosted at ${Red}smb://$MY_IP ${Yellow}or ${Red}smb://$SERVERNAME${Color_Off}"
+echo -e "${Purple}You might need to check your firewall/iptables configurations."


### PR DESCRIPTION
Solus os currently uses `eopkg` as its package manager. I have added it's support on `find_pkg()`. 
I have also added some unnecessary fine-tuning.

- Readme now has a kind of Table of content ( I assumed by generic reponame that you plan to add more serverscripts in future )

- Changed the color of server address to separately highlight it from rest of message.
- Added a reminder for user to check their firewall configuration (before they blame it on script).
- Added a `sudo check` at start of script. Script is pretty useless without higher privileges. 
- Piped `MY_IP` through  `head -n 1` because without it, It was also adding ipv6 address and a linefeed. 

I have done following testing.
- Shared files between my machines running Solus, Manjaro, Fedora.
- Shared files using Android. (That's where firewall gave me trouble for some reason)

I also ran through shellcheck.net It gave following warnings. 
- unused variables ( variables for colors )
- Unquoted variables in `read` and not using `-r` while taking input
- Using `which` keyword which is non-standard.
I didn't changed those as they were just warning, and I didn't want to change your scripting style. Maybe suggestions for v2